### PR TITLE
Fix Issue #12

### DIFF
--- a/src/components/Game.svelte
+++ b/src/components/Game.svelte
@@ -107,7 +107,6 @@
 	}
 
 	function lose() {
-		++game.guesses;
 		game.active = false;
 		setTimeout(() => (showStats = true), delay);
 		if (!modeData.modes[$mode].historical) {

--- a/src/components/Game.svelte
+++ b/src/components/Game.svelte
@@ -160,7 +160,7 @@
 			if ($settings.tutorial) $settings.tutorial = 0;
 			board.hideCtx();
 		}}
-		bind:value={game.board.words[game.guesses]}
+		bind:value={game.board.words[game.guesses === ROWS ? 0 : game.guesses]}
 		on:submitWord={submitWord}
 		on:esc={() => {
 			showTutorial = false;


### PR DESCRIPTION
Per issue #12: These two changes to Game.svelte should remove the issue that occurs when a page is reloaded twice after either winning on the 6th guess, or losing the game.