### PR TITLE
Add Tile .front color just before evaluating

### DIFF
--- a/src/components/board/Tile.svelte
+++ b/src/components/board/Tile.svelte
@@ -72,6 +72,7 @@
 	}
 	.front {
 		border: 2px solid var(--border-primary);
+		color: var(--fg-primary);
 		transform: rotateX(0deg);
 	}
 	.back {


### PR DESCRIPTION
In Light mode, the Tile letter color changes from black to white before the tile is flipped (when evaluating).
This keeps the letter color as black before the tile is flipped.