### PR TITLE
Sync timer with daily game

### DIFF
--- a/src/components/widgets/Timer.svelte
+++ b/src/components/widgets/Timer.svelte
@@ -10,16 +10,17 @@
 	const HOUR = 3600000;
 	const MINUTE = 60000;
 	const SECOND = 1000;
+	const OFFSET = 25200000;
 	let ms = 1000;
 
 	let countDown: number;
 
 	export function reset(m: GameMode) {
 		clearInterval(countDown);
-		ms = modeData.modes[m].unit - (new Date().valueOf() - modeData.modes[m].seed);
+		ms = modeData.modes[m].unit - (new Date().valueOf() - modeData.modes[m].seed - OFFSET);
 		if (ms < 0) dispatch("timeup");
 		countDown = setInterval(() => {
-			ms = modeData.modes[m].unit - (new Date().valueOf() - modeData.modes[m].seed);
+			ms = modeData.modes[m].unit - (new Date().valueOf() - modeData.modes[m].seed - OFFSET);
 			if (ms < 0) {
 				clearInterval(countDown);
 				dispatch("timeup");


### PR DESCRIPTION
Issue: Timer in the stats showed an advanced clock

Change: For continuity with the changes to the daily game, subtract 7hr from UTC value.

_Test platforms: iOS/Android Safari/Chrome_