### PR TITLE
fix: ✏️ "th" ending for numbers over 3

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,7 +159,7 @@ export function contractNum(n: number) {
 		case 1: return `${n}st`;
 		case 2: return `${n}nd`;
 		case 3: return `${n}rd`;
-		default: return `${n}rd`;
+		default: return `${n}th`;
 	}
 }
 


### PR DESCRIPTION
Just a simple fix for a typo here which currently causes messages like "4rd" and "5rd".