### PR TITLE
Fix for Issue 69 duplicate letters bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@
 </div>
 
 ---
+
+# Craig Veiner's Notes
+
+### Thank You Mikha Davids
+- This is a fork of Mikha Davids' Wordle+ repository at https://github.com/MikhaD/wordle
+
+### To run a svelte app...
+- Open a terminal in the app's root folder.
+- npm install // one time install of svelte dependencies
+- npm run dev // gives link to run and debug app in html browser
+- In Brave, select menu "More tools > Development tools Ctrl+Shift+I" to open the Development tools panel, which can be floating or docked to the right side. Use the "Console" tab to see "console.log(variable)".
+
+### To run the hidden "Reset your stats" function...
+- Click on the Wordle+ Settings icon (the gear icon).
+- Hover your mouse over the words "Infinite word #xyz" in the bottom right corner of the window and the following message will pop up: "double click to reset your stats".
+- Keeping your mouse in the same place, double click your mouse.
+- The following message will briefly pop up: "localStorage cleared".
+- All your stats will be erased, and you will be able to play any game number that you have already played from the beginning, with new guesses.
+
+### Craig's Research and Modifications
+- Board.svelte\context calls utils.ts\getRowData to filter utils.ts\words.words to pAnsWords list of remaining solutions.
+- utils.ts\getRowData has a "duplicate letters bug" that returns false remaining solution(s) for the case where the tiles have revealed duplicate letters. This is the same bug as Mikha Davids' Wordle repository Issue #69 titled "Potential answer / guess count displayed 0 for 'Dolly' ".
+- To replicate the "duplicate letters bug", revert the following code in the utils.ts\getRowData function from "if (occurrences < e[1][0]) {" to "if (!occurrences || (e[1][1] && occurrences !== e[1][0])) {". Then, play any of the games below with and without the reverted change, double click the row after the suggested guess and Board.svelt\context will log out pAnsWords (the list of remaining solutions) to the Console tab of the browser's Development tools panel.
+- http://localhost:5173/wordle/#infinite/43873602 dolly, try guess "lolly" or "lowly" after guesses "slate" and "broil". Reference Mikha Davids' Wordle repository Issue #69 titled "Potential answer / guess count displayed 0 for 'Dolly' ".
+- http://localhost:5173/wordle/#infinite/63769522 beefy, try guess "greed" after guess "slate".
+- http://localhost:5173/wordle/#infinite/63781582 gloom, try guess "boozy" after guess "trace".
+
+### Mikha Davids' original ReadMe.md continues below.
+
+# Wordle Overview
 A recreation of the popular game [Wordle](https://www.nytimes.com/games/wordle/) by Josh Wardle (now purchased by the New York Times), with additional modes and features.
 Hosted on GitHub pages [here](https://mikhad.github.io/wordle/).
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,5 +67,5 @@
 
 <Toaster bind:this={toaster} />
 {#if toaster}
-	<Game {stats} bind:word {toaster} bind:game={state} />
+	<Game {stats} bind:solution={word} {toaster} bind:game={state} />
 {/if}

--- a/src/components/Game.svelte
+++ b/src/components/Game.svelte
@@ -35,7 +35,7 @@
 	} from "../utils";
 	import { letterStates, settings, mode } from "../stores";
 
-	export let word: string;
+	export let solution: string;
 	export let stats: Stats;
 	export let game: GameState;
 	export let toaster: Toaster;
@@ -78,11 +78,11 @@
 					game.validHard = false;
 				}
 			}
-			game.board.state[game.guesses] = game.guess(word);
+			game.board.state[game.guesses] = game.guess(solution);
 			++game.guesses;
 			$letterStates.update(game.lastState, game.lastWord);
 			$letterStates = $letterStates;
-			if (game.lastWord === word) win();
+			if (game.lastWord === solution) win();
 			else if (game.guesses === ROWS) lose();
 		} else {
 			toaster.pop("Not in word list");
@@ -125,7 +125,8 @@
 		modeData.modes[$mode].historical = false;
 		modeData.modes[$mode].seed = newSeed($mode);
 		game = new GameState($mode, localStorage.getItem(`state-${$mode}`));
-		word = words.words[seededRandomInt(0, words.words.length, modeData.modes[$mode].seed)];
+		solution = words.words[seededRandomInt(0, words.words.length, modeData.modes[$mode].seed)];
+		console.log("Cheat. The solution is: " + solution);
 		$letterStates = new LetterStates();
 		showStats = false;
 		showRefresh = false;
@@ -220,7 +221,7 @@
 	</Separator>
 	<ShareGame wordNumber={game.wordNumber} />
 	{#if !game.active}
-		<Definition {word} alternates={2} />
+		<Definition word={solution} alternates={2} />
 	{:else}
 		<!-- Fade with delay is to prevent a bright red button from appearing as soon as refresh is pressed -->
 		<div

--- a/src/components/board/Board.svelte
+++ b/src/components/board/Board.svelte
@@ -29,6 +29,7 @@
 	let x = 0;
 	let y = 0;
 	let word = "";
+	let pAnsWords: string[] = [];
 
 	function context(cx: number, cy: number, num: number, val: string) {
 		if (guesses >= num) {
@@ -38,7 +39,8 @@
 			word = guesses > num ? val : "";
 
 			const match = getRowData(num, board);
-			pAns = words.words.filter((w) => match(w)).length;
+			pAnsWords = words.words.filter((w) => match(w));
+			pAns = pAnsWords.length;
 			pSols = pAns + words.valid.filter((w) => match(w)).length;
 		}
 	}
@@ -69,7 +71,7 @@
 </script>
 
 {#if showCtx}
-	<ContextMenu {pAns} {pSols} {x} {y} {word} />
+	<ContextMenu {pAns} {pSols} {x} {y} {word} {pAnsWords} />
 {/if}
 
 <div class="board" on:touchstart={swipeStart} on:touchend={swipeEnd} on:touchmove|preventDefault>

--- a/src/components/widgets/ContextMenu.svelte
+++ b/src/components/widgets/ContextMenu.svelte
@@ -6,29 +6,24 @@
 	export let word = "";
 	export let pAns: number;
 	export let pSols: number;
+	export let pAnsWords: string[];
 	const width = +getComputedStyle(document.body).getPropertyValue("--game-width") / 2;
 
 	$: x = window.innerWidth - x < width ? window.innerWidth - width : x;
 </script>
 
 <div class="ctx-menu" style="top: {y}px; left: {x}px;">
+	<div>
+		Before guessing "{word}" there were
+		<br /><br />
+		{pAns} possible answer{pAns > 1 ? "s" : ""}
+		<br />
+		{#if void console.log(`${pAns} possible answers before guessing "${word}": ${pAnsWords}`)} "" {/if}
+		{pSols} valid guess{pSols > 1 ? "es" : ""}
+		<br />
+	</div>
 	{#if word !== ""}
-		<div>
-			Considering all hints, this row had:
-			<br /><br />
-			{pAns} possible answer{pAns > 1 ? "s" : ""}
-			<br />
-			{pSols} valid guess{pSols > 1 ? "es" : ""}
-		</div>
 		<Definition {word} alternates={1} />
-	{:else}
-		<div>
-			Considering all hints, there {pAns > 1 ? "are" : "is"}:
-			<br /><br />
-			{pAns} possible answer{pAns > 1 ? "s" : ""}
-			<br />
-			{pSols} valid guess{pSols > 1 ? "es" : ""}
-		</div>
 	{/if}
 </div>
 

--- a/src/components/widgets/stats/Distribution.svelte
+++ b/src/components/widgets/stats/Distribution.svelte
@@ -11,6 +11,12 @@
 </script>
 
 <h3>guess distribution</h3>
+<div class="guess">
+	{#if game.guesses && !game.active && !failed(game)}
+		<h4>{game.guesses} Guesses in last game.</h4>
+		<br />
+	{/if}
+</div>
 <div class="container">
 	{#each Object.entries(distribution) as guess, i (guess[0])}
 		{@const g = Number(guess[0])}


### PR DESCRIPTION
- utils.ts\getRowData has a "duplicate letters bug" that returns false remaining solution(s) for the case where the tiles have revealed duplicate letters. This is the same bug as Mikha Davids' Wordle repository Issue #69 titled "Potential answer / guess count displayed 0 for 'Dolly' ".
- To replicate the "duplicate letters bug", revert the following code in the utils.ts\getRowData function from "if (occurrences < e[1][0]) {" to "if (!occurrences || (e[1][1] && occurrences !== e[1][0])) {". Then, play any of the games below with and without the reverted change, double click the row after the suggested guess and Board.svelt\context will log out pAnsWords (the list of remaining solutions) to the Console tab of the browser's Development tools panel.
- http://localhost:5173/wordle/#infinite/43873602 dolly, try guess "lolly" or "lowly" after guesses "slate" and "broil". Reference Mikha Davids' Wordle repository Issue #69 titled "Potential answer / guess count displayed 0 for 'Dolly' ".
- http://localhost:5173/wordle/#infinite/63769522 beefy, try guess "greed" after guess "slate".
- http://localhost:5173/wordle/#infinite/63781582 gloom, try guess "boozy" after guess "trace".
- Board.svelte\context calls utils.ts\getRowData to filter utils.ts\words.words to pAnsWords list of remaining solutions.
- Mikha, thank you so much for the great work you did in Wordle+, and for sharing it / making it open source.
- Mikha, in order to understand your code better and to help me find the bug, I renamed a variable or two and added some comments and console logging. You may not want to keep some of these "cosmetic" changes.